### PR TITLE
Update community link with current URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _Please do not report issues with this software to New Relic Global Technical Su
 
 New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorer's Hub. You can find this project's topic/threads here:
 
-[https://discuss.newrelic.com/c/build-on-new-relic/nr1-github](https://discuss.newrelic.com/c/build-on-new-relic/nr1-github)
+[https://discuss.newrelic.com/t/github-nerdpack/82932](https://discuss.newrelic.com/t/github-nerdpack/82932)
 *(Note: URL subject to change before GA)*
 
 ### Issues / Enhancement Requests


### PR DESCRIPTION
The original link was a "placeholder"—I have updated the README with the correct community link.
