### PR TITLE
Fixing issue with incorrect github api URL

### DIFF
--- a/CONFIGURE_ME.js
+++ b/CONFIGURE_ME.js
@@ -1,6 +1,6 @@
 // specify the location of the github instance you want to use for your
 // deployment of this NerdPack.
-// specify as a full url (with no trailing slash) e.g. https://github.com
+// specify as a full url (with no trailing slash) e.g. https://api.github.com
 //
 // if you want to ignore changes to this file for git commit/push purposes,
 // try running this:

--- a/nerdlets/github-about/github.js
+++ b/nerdlets/github-about/github.js
@@ -13,7 +13,7 @@ export default class GitHub {
   }
 
   async call(httpMethod, path, payload) {
-    const url = `${GITHUB_URL}/api/v3/${path}`;
+    const url = `${GITHUB_URL}/${path}`;
     const options = {
       method: httpMethod,
       headers: {


### PR DESCRIPTION
When using the master branch, github api URL `github.com/api/v3` is returning 404 as it is now `api.github.com` 

This change now allows the nerdlet to run.

