### PR TITLE
feat: Account based GitHub URL configuration

### DIFF
--- a/CONFIGURE_ME.js
+++ b/CONFIGURE_ME.js
@@ -5,7 +5,7 @@
 // if you want to ignore changes to this file for git commit/push purposes,
 // try running this:
 // git update-index --assume-unchanged ./CONFIGURE_ME.js
-//if you're accessing public GitHub, use the commented variable value below
-//const GITHUB_URL = `https://api.github.com`
-const GITHUB_URL = null
-export default GITHUB_URL
+// if you're accessing public GitHub, use the commented variable value below
+// const GITHUB_URL = `https://api.github.com`
+const GITHUB_URL = null;
+export default GITHUB_URL;

--- a/nerdlets/github-about/configure-me.js
+++ b/nerdlets/github-about/configure-me.js
@@ -1,27 +1,83 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Header from './header';
 
-export default function ConfigureMe() {
-  return (
-    <div className="root">
-      <Header />
-      <h2>Integrate with GitHub</h2>
-      <p>
-        Ever wondered what a service does, or who's been working on it? Answer
-        these questions and more with this GitHub integration!
-      </p>
-      <h2>First Things First.</h2>
-      <p>
-        Let's get you started! Set up this Nerdpack by configuring your
-        organization's GitHub URL. It could be the public{' '}
-        <a href="https://github.com">https://github.com</a> or it could be a
-        private GitHub enterprise instance.
-      </p>
-      <p>
-        Edit the URL in <code>CONFIGURE_ME.js</code> and come back here when
-        you've saved the file. Don't deploy this Nerdpack without proper
-        configuration!
-      </p>
-    </div>
-  );
+export default class ConfigureMe extends React.Component {
+  static propTypes = {
+    githubUrl: PropTypes.string,
+    onUpdate: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      accountSettings: {
+        githubUrl: props.githubUrl || ''
+      }
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.onUpdate = props.onUpdate.bind(this);
+  }
+
+  handleChange({ field, value }) {
+    this.setState(previousState => {
+      const updatedSettings = {
+        ...previousState.accountSettings
+      };
+      updatedSettings[field] = value;
+
+      return {
+        ...previousState,
+        accountSettings: updatedSettings
+      };
+    });
+  }
+
+  handleSubmit(e) {
+    const { onUpdate } = this.props;
+    const { accountSettings } = this.state;
+
+    e.preventDefault();
+    onUpdate({ accountSettings });
+  }
+
+  render() {
+    return (
+      <div className="root">
+        <Header />
+        <h2>Integrate with GitHub</h2>
+        <p>
+          Ever wondered what a service does, or who's been working on it? Answer
+          these questions and more with this GitHub integration!
+        </p>
+        <h2>First Things First.</h2>
+        <p>
+          Let's get you started! Set up this Nerdpack by configuring your
+          organization's GitHub URL. It could be the public{' '}
+          <a href="https://github.com">https://github.com</a> or it could be a
+          private GitHub enterprise instance.
+        </p>
+        <form onSubmit={this.handleSubmit}>
+          <label>
+            Github Url:
+            <input
+              type="text"
+              value={this.state.value}
+              onChange={e =>
+                this.handleChange({ field: 'githubUrl', value: e.target.value })
+              }
+            />
+          </label>
+          <input type="submit" value="Submit" />
+        </form>
+        {/* <p>
+          Edit the URL in <code>CONFIGURE_ME.js</code> and come back here when
+          you've saved the file. Don't deploy this Nerdpack without proper
+          configuration!
+        </p> */}
+      </div>
+    );
+  }
 }

--- a/nerdlets/github-about/contributors.js
+++ b/nerdlets/github-about/contributors.js
@@ -98,7 +98,7 @@ export default class Contributors extends React.Component {
       const committerList = Object.values(committers).sort(
         (x, y) => y.commitCount - x.commitCount
       );
-      this.setState({ committers: committerList });
+      this.setState({ error: null, committers: committerList });
     } catch (e) {
       this.setState({
         error:

--- a/nerdlets/github-about/contributors.js
+++ b/nerdlets/github-about/contributors.js
@@ -9,7 +9,7 @@ export default class Contributors extends React.Component {
     userToken: PropTypes.string,
     project: PropTypes.string,
     owner: PropTypes.string,
-    repository: PropTypes.string
+    repoUrl: PropTypes.string
   };
 
   constructor(props) {
@@ -25,7 +25,7 @@ export default class Contributors extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (
-      prevProps.repository !== this.props.repository ||
+      prevProps.repoUrl !== this.props.repoUrl ||
       (!prevProps.isSetup && this.props.isSetup)
     ) {
       this.load();

--- a/nerdlets/github-about/contributors.js
+++ b/nerdlets/github-about/contributors.js
@@ -6,7 +6,7 @@ export default class Contributors extends React.Component {
   static propTypes = {
     githubUrl: PropTypes.string,
     isSetup: PropTypes.bool,
-    userToken: PropTypes.string.isRequired,
+    userToken: PropTypes.string,
     project: PropTypes.string,
     owner: PropTypes.string,
     repository: PropTypes.string

--- a/nerdlets/github-about/github.js
+++ b/nerdlets/github-about/github.js
@@ -38,6 +38,7 @@ export default class GitHub {
       const response = await fetch(url, options);
       return response.json();
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.debug(e);
       return e;
     }

--- a/nerdlets/github-about/github.js
+++ b/nerdlets/github-about/github.js
@@ -1,24 +1,24 @@
-import GITHUB_URL from '../../CONFIGURE_ME';
-
 export default class GitHub {
-  constructor(userToken) {
+  constructor({ userToken, githubUrl }) {
     this.token = userToken;
+    this.githubUrl = githubUrl;
   }
 
   // attempt to reach the github instance. Throw an execption
   // if it's not reachable (e.g. user is not on a VPN)
   static async ping() {
-    const GHURL = GITHUB_URL.trim();
+    const GHURL = this.githubUrl.trim();
     const request = { mode: 'no-cors', 'Content-Type': 'application/json' };
     fetch(`${GHURL}/status`, request);
   }
 
   async call(httpMethod, path, payload) {
-    const GHURL = GITHUB_URL.trim();
+    const GHURL = this.githubUrl.trim();
     const url =
-      GHURL.indexOf('api.github.com') === -1
-        ? `${GHURL}/api/v3/${path}`
-        : `${GHURL}/${path}`;
+      GHURL.indexOf('api.github.com') > 0
+        ? `${GHURL}/${path}` // github.com
+        : `${GHURL}/api/v3/${path}`; // GHE
+
     const options = {
       method: httpMethod,
       // mode: 'no-cors',
@@ -29,12 +29,18 @@ export default class GitHub {
         Authorization: `token ${this.token}`
       }
     };
+
     if (payload) {
       options.body = JSON.stringify(payload);
     }
-    const response = await fetch(url, options);
-    // console.debug(response);
-    return response.json();
+
+    try {
+      const response = await fetch(url, options);
+      return response.json();
+    } catch (e) {
+      console.debug(e);
+      return e;
+    }
   }
 
   async get(path) {

--- a/nerdlets/github-about/header.js
+++ b/nerdlets/github-about/header.js
@@ -14,8 +14,8 @@ export default function Header({ repoUrl }) {
         <StackItem>
           <img src={GitHubLogo} className="github-logo" />
         </StackItem>
-        <StackItem className="repo-link-stack">
-          {repoUrl && (
+        {repoUrl && (
+          <StackItem className="repo-link-stack">
             <a
               href={repoUrl}
               target="_blank"
@@ -24,8 +24,8 @@ export default function Header({ repoUrl }) {
             >
               {repoUrl}
             </a>
-          )}
-        </StackItem>
+          </StackItem>
+        )}
       </Stack>
     </div>
   );

--- a/nerdlets/github-about/main.js
+++ b/nerdlets/github-about/main.js
@@ -214,7 +214,8 @@ export default class GithubAbout extends React.Component {
 
   renderTabs() {
     const { entity, githubUrl, repoUrl, userToken, visibleTab } = this.state;
-    const isSetup = userToken !== null && githubUrl !== null;
+    const isSetup =
+      userToken !== null && userToken !== undefined && githubUrl !== null;
     const hasRepoUrl = repoUrl !== null && repoUrl !== '';
     const isDisabled = !isSetup || !hasRepoUrl;
     const { owner, project } = this.parseRepoUrl(repoUrl);

--- a/nerdlets/github-about/main.js
+++ b/nerdlets/github-about/main.js
@@ -48,6 +48,7 @@ export default class GithubAbout extends React.Component {
 
     this.state = {
       entity: null,
+      entityNotFound: null,
       accountId: null,
       githubUrl: null,
       visibleTab: null
@@ -96,7 +97,12 @@ export default class GithubAbout extends React.Component {
     const repoUrl = get(data, 'actor.entity.nerdStorage.repoUrl.repoUrl');
     const { user, entity } = data.actor;
 
-    this.setState({ user, entity, userToken, repoUrl });
+    if (entity === null) {
+      this.setState({ entityNotFound: true });
+      return;
+    }
+
+    this.setState({ user, entity, entityNotFound: null, userToken, repoUrl });
   }
 
   handleTabClick(tabName) {
@@ -302,11 +308,26 @@ export default class GithubAbout extends React.Component {
     );
   }
 
+  renderEntityNotFound() {
+    return (
+      <div className="root">
+        <div className="container">
+          <Header />
+          <h2>Entity not found for this Account</h2>
+        </div>
+      </div>
+    );
+  }
+
   render() {
-    const { githubAccessError, user } = this.state;
+    const { entityNotFound, githubAccessError, user } = this.state;
 
     if (githubAccessError) {
       return this.renderGithubAccessError();
+    }
+
+    if (entityNotFound) {
+      return this.renderEntityNotFound();
     }
 
     if (!user) {

--- a/nerdlets/github-about/main.js
+++ b/nerdlets/github-about/main.js
@@ -216,7 +216,8 @@ export default class GithubAbout extends React.Component {
     const { entity, githubUrl, repoUrl, userToken, visibleTab } = this.state;
     const isSetup =
       userToken !== null && userToken !== undefined && githubUrl !== null;
-    const hasRepoUrl = repoUrl !== null && repoUrl !== '';
+    const hasRepoUrl =
+      repoUrl !== null && repoUrl !== '' && repoUrl !== undefined;
     const isDisabled = !isSetup || !hasRepoUrl;
     const { owner, project } = this.parseRepoUrl(repoUrl);
 

--- a/nerdlets/github-about/readme.js
+++ b/nerdlets/github-about/readme.js
@@ -55,7 +55,7 @@ export default class ReadMe extends React.Component {
 
     github.get(path).then(response => {
       const readme = atob(response.content);
-      this.setState({ readme });
+      this.setState({ error: null, readme });
     });
   }
 

--- a/nerdlets/github-about/readme.js
+++ b/nerdlets/github-about/readme.js
@@ -6,34 +6,75 @@ import Github from './github';
 
 export default class ReadMe extends React.Component {
   static propTypes = {
+    githubUrl: PropTypes.string,
+    isSetup: PropTypes.bool,
     owner: PropTypes.string,
     userToken: PropTypes.string,
     repoUrl: PropTypes.string,
     project: PropTypes.string
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      readme: ''
+    };
+  }
+
   componentDidMount() {
     this.load();
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.repoUrl !== this.props.repoUrl) {
+    if (
+      prevProps.repoUrl !== this.props.repoUrl ||
+      (!prevProps.isSetup && this.props.isSetup)
+    ) {
       this.load();
     }
   }
 
   load() {
-    const { owner, project, userToken } = this.props;
-    const github = new Github(userToken);
+    const { isSetup, githubUrl, owner, project, userToken } = this.props;
+    // console.log(isSetup);
+
+    if (!isSetup) {
+      return;
+    }
+
+    const github = new Github({ userToken, githubUrl });
     const path = `repos/${owner}/${project}/readme`;
+
+    // Bad url
+    if (path.indexOf('//') > 0) {
+      const error = new Error(`Bad repository url: ${path}`);
+      this.setState({ error: error.message });
+      return;
+    }
+
     github.get(path).then(response => {
       const readme = atob(response.content);
-      this.setState({ readme }); // eslint-disable-line react/no-unused-state
+      this.setState({ readme });
     });
   }
 
+  renderError() {
+    const { error } = this.state;
+    return (
+      <>
+        <h2>An error occurred:</h2>
+        <p>{error}</p>
+      </>
+    );
+  }
+
   render() {
-    const { readme } = this.state || {};
+    const { error, readme } = this.state;
+
+    if (error) {
+      return this.renderError();
+    }
 
     return (
       <div className="markdown-body">

--- a/nerdlets/github-about/repo-picker.js
+++ b/nerdlets/github-about/repo-picker.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import GITHUB_URL from '../../CONFIGURE_ME';
 import { Button, Stack, StackItem, TextField, Spinner } from 'nr1';
 import Github from './github';
 import Header from './header';
@@ -78,6 +76,7 @@ export default class RepoPicker extends React.Component {
     github.get(path).then(suggestions => {
       if (suggestions.items && suggestions.items.length > 0) {
         this.setState({ suggestions: suggestions.items });
+        return;
       }
       this.setState({ error: 'Error fetching suggestions' });
     });
@@ -158,7 +157,7 @@ export default class RepoPicker extends React.Component {
 
   renderSuggestions() {
     const { suggestions } = this.state;
-    const { isSetup, repoUrl, entity } = this.props;
+    const { isSetup, repoUrl, entity, githubUrl } = this.props;
 
     if (!isSetup) {
       return;
@@ -187,8 +186,8 @@ export default class RepoPicker extends React.Component {
 
     let hasMatch = false;
     const GHURL =
-      GITHUB_URL.indexOf('api.github.com') === -1
-        ? GITHUB_URL.trim()
+      githubUrl && githubUrl.indexOf('api.github.com') === -1
+        ? githubUrl.trim()
         : 'https://github.com';
     const searchUrl = `${GHURL}/search?q=${this.getSearchQuery()}`;
     // limit to top 5 suggestions
@@ -221,7 +220,7 @@ export default class RepoPicker extends React.Component {
   render() {
     const { error, suggestions } = this.state;
 
-    console.debug(error);
+    // console.debug(error);
 
     if (!suggestions && error === null) return <Spinner fillContainer />;
 

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-did-update-set-state */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -6,53 +7,40 @@ import { TextField, Button, Stack, StackItem, Grid, GridItem } from 'nr1';
 export default class Setup extends React.PureComponent {
   static propTypes = {
     githubUrl: PropTypes.string,
+    setGithubUrl: PropTypes.func.isRequired,
     setUserToken: PropTypes.func.isRequired,
-    userToken: PropTypes.string,
-    onUpdate: PropTypes.func
+    userToken: PropTypes.string
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      accountSettings: {
-        githubUrl: props.githubUrl || ''
-      }
+      userToken: props.userToken || '',
+      githubUrl: props.githubUrl || ''
     };
-
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.onUpdate = props.onUpdate.bind(this);
   }
 
-  handleChange({ field, value }) {
-    this.setState(previousState => {
-      const updatedSettings = {
-        ...previousState.accountSettings
-      };
-      updatedSettings[field] = value;
-
-      return {
-        ...previousState,
-        accountSettings: updatedSettings
-      };
-    });
+  componentDidUpdate(prevProps) {
+    const { githubUrl, userToken } = this.props;
+    if (prevProps.githubUrl !== githubUrl) {
+      this.setState({ githubUrl });
+    }
+    if (prevProps.userToken !== userToken) {
+      this.setState({ userToken });
+    }
   }
 
-  handleSubmit(e) {
-    const { onUpdate } = this.props;
-    const { accountSettings } = this.state;
-
-    e.preventDefault();
-    onUpdate({ accountSettings });
+  _getGithubUrl() {
+    const { githubUrl } = this.state;
+    return githubUrl && githubUrl.indexOf('api.github.com') === -1
+      ? githubUrl.trim()
+      : 'https://github.com';
   }
 
   renderUserTokenInput() {
-    const { userToken } = this.state || {};
-    const { githubUrl, setUserToken } = this.props;
-    const GHURL =
-      githubUrl.indexOf('api.github.com') === -1
-        ? githubUrl.trim()
-        : 'https://github.com';
+    const { userToken } = this.state;
+    const { setUserToken } = this.props;
+    const GHURL = this._getGithubUrl();
     return (
       <StackItem>
         <h2>2. Personal Access Token</h2>
@@ -75,7 +63,7 @@ export default class Setup extends React.PureComponent {
               label="GitHub Token"
               placeholder="Paste your user token here"
               onChange={({ target }) => {
-                this.setState({ userToken: target.value }); // eslint-disable-line react/no-unused-state
+                this.setState({ userToken: target.value });
               }}
             />
           </StackItem>
@@ -99,11 +87,8 @@ export default class Setup extends React.PureComponent {
   }
 
   renderDeleteUserToken() {
-    const { setUserToken, githubUrl } = this.props;
-    const GHURL =
-      githubUrl.indexOf('api.github.com') === -1
-        ? githubUrl.trim()
-        : 'https://github.com';
+    const { setUserToken } = this.props;
+    const GHURL = this._getGithubUrl();
     return (
       <StackItem>
         <h2>2. Personal Access Token</h2>
@@ -134,52 +119,57 @@ export default class Setup extends React.PureComponent {
     );
   }
 
+  renderGithubUrlInput() {
+    const { setGithubUrl } = this.props;
+    const { githubUrl } = this.state;
+
+    return (
+      <StackItem>
+        <h1>Integrate with GitHub</h1>
+        <p>
+          Ever wondered what a Service does, or who has been working on it?
+          Answer these questions and more with this GitHub integration!
+        </p>
+        <Stack alignmentType="center">
+          <StackItem>
+            <h2>1. First Things First.</h2>
+            <p>
+              Let's get you started! Set up this Nerdpack by configuring your
+              organization's GitHub URL. It could be the public{' '}
+              <a href="https://github.com">https://github.com</a> or it could be
+              a private GitHub enterprise instance.
+            </p>
+            <TextField
+              autofocus
+              label="GitHub Url"
+              placeholder="Provide your Github instance URL"
+              onChange={({ target }) => {
+                this.setState({ githubUrl: target.value });
+              }}
+              value={githubUrl}
+            />
+          </StackItem>
+          <StackItem>
+            <Button
+              onClick={() => setGithubUrl(githubUrl)}
+              disabled={!githubUrl}
+              type="primary"
+            >
+              Set Your GitHub URL
+            </Button>
+          </StackItem>
+        </Stack>
+      </StackItem>
+    );
+  }
+
   render() {
     const { userToken } = this.props;
     return (
       <Grid className="container integration-container">
         <GridItem columnSpan={8}>
           <Stack directionType="vertical" gapType={Stack.GAP_TYPE.EXTRA_LOOSE}>
-            <StackItem>
-              <h1>Integrate with GitHub</h1>
-              <p>
-                Ever wondered what a Service does, or who has been working on
-                it? Answer these questions and more with this GitHub
-                integration!
-              </p>
-              <Stack alignmentType="center">
-                <StackItem grow>
-                  <h2>1. First Things First.</h2>
-                  <p>
-                    Let's get you started! Set up this Nerdpack by configuring
-                    your organization's GitHub URL. It could be the public{' '}
-                    <a href="https://github.com">https://github.com</a> or it
-                    could be a private GitHub enterprise instance.
-                  </p>
-                  <TextField
-                    autofocus
-                    label="GitHub Url"
-                    placeholder="Provide your Github instance URL"
-                    onChange={e =>
-                      this.handleChange({
-                        field: 'githubUrl',
-                        value: e.target.value
-                      })
-                    }
-                  />
-                </StackItem>
-                <StackItem>
-                  <Button
-                    onClick={() => this.handleSubmit()}
-                    disabled={!userToken || userToken.length !== 40}
-                    type="primary"
-                  >
-                    Set Your GitHub URL
-                  </Button>
-                </StackItem>
-              </Stack>
-            </StackItem>
-
+            {this.renderGithubUrlInput()}
             {!userToken && this.renderUserTokenInput()}
             {userToken && this.renderDeleteUserToken()}
           </Stack>

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -42,7 +42,7 @@ export default class Setup extends React.PureComponent {
     const { setUserToken } = this.props;
     const GHURL = this._getGithubUrl();
     return (
-      <StackItem>
+      <StackItem className="integration-step-container">
         <h2>2. Personal Access Token</h2>
         <p>
           To get started,{' '}
@@ -56,7 +56,7 @@ export default class Setup extends React.PureComponent {
           for your GitHub account. You don't need to give the token any special
           access scopes.
         </p>
-        <Stack alignmentType="center">
+        <Stack fullWidth verticalType={Stack.VERTICAL_TYPE.BOTTOM} className="integration-input-container">
           <StackItem grow>
             <TextField
               autofocus
@@ -77,11 +77,11 @@ export default class Setup extends React.PureComponent {
             </Button>
           </StackItem>
         </Stack>
-        <p>
+        <small>
           <strong>Remember</strong> if using a private github repository, be
           sure you are connected to your organization's private network to
           access it.
-        </p>
+        </small>
       </StackItem>
     );
   }
@@ -131,7 +131,7 @@ export default class Setup extends React.PureComponent {
           Answer these questions and more with this GitHub integration!
         </p>
         <Stack alignmentType="center">
-          <StackItem>
+          <StackItem className="integration-step-container">
             <h2>1. First Things First.</h2>
             <p>
               Let's get you started! Set up this Nerdpack by configuring your
@@ -139,24 +139,28 @@ export default class Setup extends React.PureComponent {
               <a href="https://github.com">https://github.com</a> or it could be
               a private GitHub enterprise instance.
             </p>
-            <TextField
-              autofocus
-              label="GitHub Url"
-              placeholder="Provide your Github instance URL"
-              onChange={({ target }) => {
-                this.setState({ githubUrl: target.value });
-              }}
-              value={githubUrl}
-            />
-          </StackItem>
-          <StackItem>
-            <Button
-              onClick={() => setGithubUrl(githubUrl)}
-              disabled={!githubUrl}
-              type="primary"
-            >
-              Set Your GitHub URL
-            </Button>
+            <Stack fullWidth verticalType={Stack.VERTICAL_TYPE.BOTTOM} className="integration-input-container">
+              <StackItem grow>
+                <TextField
+                  autofocus
+                  label="GitHub Url"
+                  placeholder="Provide your Github instance URL"
+                  onChange={({ target }) => {
+                    this.setState({ githubUrl: target.value });
+                  }}
+                  value={githubUrl}
+                />
+              </StackItem>
+              <StackItem>
+                <Button
+                  onClick={() => setGithubUrl(githubUrl)}
+                  disabled={!githubUrl}
+                  type="primary"
+                >
+                  Set Your GitHub URL
+                </Button>
+              </StackItem>
+            </Stack>
           </StackItem>
         </Stack>
       </StackItem>

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -1,25 +1,61 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import GITHUB_URL from '../../CONFIGURE_ME';
 import { TextField, Button, Stack, StackItem, Grid, GridItem } from 'nr1';
 
 export default class Setup extends React.PureComponent {
   static propTypes = {
+    githubUrl: PropTypes.string,
     setUserToken: PropTypes.func.isRequired,
-    userToken: PropTypes.string
+    userToken: PropTypes.string,
+    onUpdate: PropTypes.func
   };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      accountSettings: {
+        githubUrl: props.githubUrl || ''
+      }
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.onUpdate = props.onUpdate.bind(this);
+  }
+
+  handleChange({ field, value }) {
+    this.setState(previousState => {
+      const updatedSettings = {
+        ...previousState.accountSettings
+      };
+      updatedSettings[field] = value;
+
+      return {
+        ...previousState,
+        accountSettings: updatedSettings
+      };
+    });
+  }
+
+  handleSubmit(e) {
+    const { onUpdate } = this.props;
+    const { accountSettings } = this.state;
+
+    e.preventDefault();
+    onUpdate({ accountSettings });
+  }
 
   renderUserTokenInput() {
     const { userToken } = this.state || {};
-    const { setUserToken } = this.props;
+    const { githubUrl, setUserToken } = this.props;
     const GHURL =
-      GITHUB_URL.indexOf('api.github.com') === -1
-        ? GITHUB_URL.trim()
+      githubUrl.indexOf('api.github.com') === -1
+        ? githubUrl.trim()
         : 'https://github.com';
     return (
       <StackItem>
-        <h3>Personal Access Token</h3>
+        <h2>2. Personal Access Token</h2>
         <p>
           To get started,{' '}
           <a
@@ -63,14 +99,14 @@ export default class Setup extends React.PureComponent {
   }
 
   renderDeleteUserToken() {
-    const { setUserToken } = this.props;
+    const { setUserToken, githubUrl } = this.props;
     const GHURL =
-      GITHUB_URL.indexOf('api.github.com') === -1
-        ? GITHUB_URL.trim()
+      githubUrl.indexOf('api.github.com') === -1
+        ? githubUrl.trim()
         : 'https://github.com';
     return (
       <StackItem>
-        <h3>Personal Access Token</h3>
+        <h2>2. Personal Access Token</h2>
         <p>
           You have provided a GitHub personal access token, which you can{' '}
           <a
@@ -111,7 +147,39 @@ export default class Setup extends React.PureComponent {
                 it? Answer these questions and more with this GitHub
                 integration!
               </p>
+              <Stack alignmentType="center">
+                <StackItem grow>
+                  <h2>1. First Things First.</h2>
+                  <p>
+                    Let's get you started! Set up this Nerdpack by configuring
+                    your organization's GitHub URL. It could be the public{' '}
+                    <a href="https://github.com">https://github.com</a> or it
+                    could be a private GitHub enterprise instance.
+                  </p>
+                  <TextField
+                    autofocus
+                    label="GitHub Url"
+                    placeholder="Provide your Github instance URL"
+                    onChange={e =>
+                      this.handleChange({
+                        field: 'githubUrl',
+                        value: e.target.value
+                      })
+                    }
+                  />
+                </StackItem>
+                <StackItem>
+                  <Button
+                    onClick={() => this.handleSubmit()}
+                    disabled={!userToken || userToken.length !== 40}
+                    type="primary"
+                  >
+                    Set Your GitHub URL
+                  </Button>
+                </StackItem>
+              </Stack>
             </StackItem>
+
             {!userToken && this.renderUserTokenInput()}
             {userToken && this.renderDeleteUserToken()}
           </Stack>

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -56,7 +56,11 @@ export default class Setup extends React.PureComponent {
           for your GitHub account. You don't need to give the token any special
           access scopes.
         </p>
-        <Stack fullWidth verticalType={Stack.VERTICAL_TYPE.BOTTOM} className="integration-input-container">
+        <Stack
+          fullWidth
+          verticalType={Stack.VERTICAL_TYPE.BOTTOM}
+          className="integration-input-container"
+        >
           <StackItem grow>
             <TextField
               autofocus
@@ -139,7 +143,11 @@ export default class Setup extends React.PureComponent {
               <a href="https://github.com">https://github.com</a> or it could be
               a private GitHub enterprise instance.
             </p>
-            <Stack fullWidth verticalType={Stack.VERTICAL_TYPE.BOTTOM} className="integration-input-container">
+            <Stack
+              fullWidth
+              verticalType={Stack.VERTICAL_TYPE.BOTTOM}
+              className="integration-input-container"
+            >
               <StackItem grow>
                 <TextField
                   autofocus

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -16,7 +16,8 @@ export default class Setup extends React.PureComponent {
     super(props);
     this.state = {
       userToken: props.userToken || '',
-      githubUrl: props.githubUrl || ''
+      githubUrl: props.githubUrl || '',
+      isGithubEnterprise: true
     };
   }
 
@@ -24,6 +25,9 @@ export default class Setup extends React.PureComponent {
     const { githubUrl, userToken } = this.props;
     if (prevProps.githubUrl !== githubUrl) {
       this.setState({ githubUrl });
+      if (githubUrl.indexOf('api.github.com') >= 0) {
+        this.setState({ isGithubEnterprise: false });
+      }
     }
     if (prevProps.userToken !== userToken) {
       this.setState({ userToken });
@@ -125,7 +129,7 @@ export default class Setup extends React.PureComponent {
 
   renderGithubUrlInput() {
     const { setGithubUrl } = this.props;
-    const { githubUrl } = this.state;
+    const { isGithubEnterprise, githubUrl } = this.state;
 
     return (
       <StackItem>
@@ -143,6 +147,43 @@ export default class Setup extends React.PureComponent {
               <a href="https://github.com">https://github.com</a> or it could be
               a private GitHub enterprise instance.
             </p>
+            <Stack
+              gapType={Stack.GAP_TYPE.SMALL}
+              className="integration-github-type-selection"
+            >
+              <StackItem>
+                <Button
+                  sizeType={Button.SIZE_TYPE.LARGE}
+                  type={
+                    !isGithubEnterprise
+                      ? Button.TYPE.PRIMARY
+                      : Button.TYPE.NEUTRAL
+                  }
+                  onClick={() => {
+                    setGithubUrl('https://api.github.com');
+                    this.setState({ isGithubEnterprise: false });
+                  }}
+                >
+                  Public Github
+                </Button>
+              </StackItem>
+              <StackItem>
+                <Button
+                  sizeType={Button.SIZE_TYPE.LARGE}
+                  type={
+                    isGithubEnterprise
+                      ? Button.TYPE.PRIMARY
+                      : Button.TYPE.NEUTRAL
+                  }
+                  onClick={() => {
+                    setGithubUrl('');
+                    this.setState({ isGithubEnterprise: true });
+                  }}
+                >
+                  Github Enterprise
+                </Button>
+              </StackItem>
+            </Stack>
             <Stack
               fullWidth
               verticalType={Stack.VERTICAL_TYPE.BOTTOM}
@@ -162,8 +203,8 @@ export default class Setup extends React.PureComponent {
               <StackItem>
                 <Button
                   onClick={() => setGithubUrl(githubUrl)}
-                  disabled={!githubUrl}
-                  type="primary"
+                  disabled={!isGithubEnterprise || !githubUrl}
+                  type={Button.TYPE.PRIMARY}
                 >
                   Set Your GitHub URL
                 </Button>

--- a/nerdlets/github-about/styles.scss
+++ b/nerdlets/github-about/styles.scss
@@ -126,3 +126,42 @@ ul[class*=Tabs-navigation] {
   padding: 0;
   box-shadow: none;
 }
+
+.integration-container {
+  h1, h2, h3, h4, h5 {
+    padding: 4px 0;
+    font-weight: 600;
+    color: #000d0d;
+  }
+
+  h2 {
+    font-size: 18px;
+    padding-bottom: 2px;
+  }
+
+  p {
+    font-size: 14px;
+    line-height: 22px;
+    color: #464e4e;
+    padding-bottom: 8px;
+  }
+
+  small {
+    display: block;
+    padding-top:8px;
+    font-size: 12px;
+    opacity: .5;
+    font-style: italic;
+  }
+}
+
+.integration-step-container {
+  margin-bottom: 2px;
+}
+
+.integration-input-container {
+  background-color:#f4f5f5;
+  padding: 8px 16px 16px;
+  box-sizing: border-box;
+  border-radius: 4px;
+}

--- a/nerdlets/github-about/styles.scss
+++ b/nerdlets/github-about/styles.scss
@@ -165,3 +165,7 @@ ul[class*=Tabs-navigation] {
   box-sizing: border-box;
   border-radius: 4px;
 }
+
+.integration-github-type-selection {
+  margin-bottom: 10px;
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint-fix": "eslint nerdlets/ --fix"
   },
   "nr1": {
-    "uuid": "3ec5afa1-827c-40c2-ad96-f60211467099",
+    "uuid": "2615fd8b-e216-4038-86f0-35bfc919d4d6",
     "sdkVersion": 2
   },
   "dependencies": {


### PR DESCRIPTION
Currently the application relies on the deployer of the package to configure the Github Url in `CONFIGURE_ME.js`, tightly coupling the configuration with the Nerdpack itself.

In order to be able to "subscribe" to this application in some future state, we need to move that configuration to the account-level and not rely on this config file.

This pull request attempts to pull the Github URL first from the config, and if that does not exist, expects the user to provide it for the Account tied to the Entity they are viewing.

**Pros**
A subscribe-able application
More flexible per-account Github URL configuration

**Cons**
Complex account hierarchies will have to add the Github URL once per account. We may be able to, in the future, assist with this via a bulk association or select-many accounts and configure etc.

This pull request refactors the setup screen, saving both the Github URL and the User Token.
It also makes the tabbed components intelligently direct you to:

- The setup screen if you need to provide information
- The select repo screen if you have not associated a Repository with the entity
- The README tab if the other two have already been configured