### PR TITLE
fix:Allow custom repo url when no suggestion found

### DIFF
--- a/nerdlets/github-about/repo-picker.js
+++ b/nerdlets/github-about/repo-picker.js
@@ -226,10 +226,23 @@ export default class RepoPicker extends React.Component {
 
     if (error) {
       return (
-        <>
-          <h2>An error occurred:</h2>
-          <p>{error}</p>
-        </>
+        <Stack
+          directionType={Stack.DIRECTION_TYPE.VERTICAL}
+          horizontalType={Stack.HORIZONTAL_TYPE.FILL}
+          fullWidth
+        >
+          <StackItem fullWidth>
+            <div className="error-alert alert">
+              <strong className="alert-label">Error:</strong>
+              <span className="alert-content">
+                {error}
+                {error === 'Error fetching suggestions' &&
+                  '. Provide your own repository URL below:'}
+              </span>
+            </div>
+          </StackItem>
+          <StackItem>{this.renderCustomUrlRow()}</StackItem>
+        </Stack>
       );
     }
 

--- a/nerdlets/github-about/styles.scss
+++ b/nerdlets/github-about/styles.scss
@@ -169,3 +169,19 @@ ul[class*=Tabs-navigation] {
 .integration-github-type-selection {
   margin-bottom: 10px;
 }
+
+.error-alert.alert {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1px solid #f3d3d7;
+  background-color: #f9ebed;
+  text-align: center;
+  border-radius: 3px;
+  color: #c10c20;
+
+  .alert-content {
+    margin-left: 4px;
+    font-size: 14px;
+  }
+}


### PR DESCRIPTION
When a service has a unique name that doesn't return anything from the GitHub suggestion search, the "Provide your own repository URL" now appears, so users can manually configure it and provide their own repo URL.

Thanks to [@joelbeckham](https://github.com/joelbeckham) for giving us a heads up in the issue below.

---
Closes newrelic#26