### PR TITLE
Update copy around errors and github tokens

### DIFF
--- a/nerdlets/github-about/contributors.js
+++ b/nerdlets/github-about/contributors.js
@@ -1,10 +1,12 @@
 import React from 'react';
+import { List, ListItem } from 'nr1';
 import PropTypes from 'prop-types';
 import Github from './github';
 import humanizeDuration from 'humanize-duration';
 
 export default class Contributors extends React.PureComponent {
   static propTypes = {
+    setActiveTab: PropTypes.func,
     githubUrl: PropTypes.string,
     isSetup: PropTypes.bool,
     userToken: PropTypes.string,
@@ -113,11 +115,32 @@ export default class Contributors extends React.PureComponent {
 
   render() {
     const { error, committers } = this.state;
+    const { setActiveTab } = this.props;
 
     if (error) {
       return (
         <>
           <h2>An error occurred:</h2>
+          <p>Possible issues include:</p>
+          <List>
+            <ListItem>- a repository that has moved</ListItem>
+            <ListItem>
+              - a repository within a different instance of GitHub
+            </ListItem>
+            <ListItem>- a malformed repository URL</ListItem>
+            <ListItem>
+              - a github token with insufficient permissions (if your repository
+              is private you will need a token with repo permissions)
+            </ListItem>
+          </List>
+          <br />
+          <p>
+            The repository URL can be set in the{' '}
+            <a onClick={() => setActiveTab('repository')}>repository tab</a>.
+            The github token can be deleted/replaced in the{' '}
+            <a onClick={() => setActiveTab('setup')}>setup tab</a>.
+          </p>
+          <br />
           <p>{error}</p>
         </>
       );

--- a/nerdlets/github-about/main.js
+++ b/nerdlets/github-about/main.js
@@ -322,6 +322,7 @@ export default class GithubAbout extends React.PureComponent {
             disabled={isDisabled}
           >
             <Contributors
+              setActiveTab={this._setActiveTab}
               isSetup={isSetup}
               githubUrl={githubUrl}
               repoUrl={repoUrl}

--- a/nerdlets/github-about/pull-requests.js
+++ b/nerdlets/github-about/pull-requests.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Github from './github';
-import { Link } from 'nr1';
+import { Link, List, ListItem } from 'nr1';
 import humanizeDuration from 'humanize-duration';
 
 export default class PullRequests extends React.PureComponent {
@@ -70,12 +70,26 @@ export default class PullRequests extends React.PureComponent {
       return (
         <>
           <h2>An error occurred:</h2>
+          <p>Possible issues include:</p>
+          <List>
+            <ListItem>- a repository that has moved</ListItem>
+            <ListItem>
+              - a repository within a different instance of GitHub
+            </ListItem>
+            <ListItem>- a malformed repository URL</ListItem>
+            <ListItem>
+              - a github token with insufficient permissions (if your repository
+              is private you will need a token with repo permissions)
+            </ListItem>
+          </List>
+          <br />
           <p>
-            Possible issues include a repository that has moved, is within a
-            different instance of GitHub, or has a malformed URL. The repository
-            URL can be set in the{' '}
+            The repository URL can be set in the{' '}
             <a onClick={() => setActiveTab('repository')}>repository tab</a>.
+            The github token can be deleted/replaced in the{' '}
+            <a onClick={() => setActiveTab('setup')}>setup tab</a>.
           </p>
+          <br />
           <p>{error}</p>
         </>
       );

--- a/nerdlets/github-about/setup.js
+++ b/nerdlets/github-about/setup.js
@@ -87,8 +87,8 @@ export default class Setup extends React.PureComponent {
           >
             generate a personal access token
           </a>{' '}
-          for your GitHub account. You don't need to give the token any special
-          access scopes.
+          for your GitHub account. If your repo is private you will need to{' '}
+          include the repo access scope.
         </p>
         <Stack
           fullWidth


### PR DESCRIPTION
This update includes a prompt to check the scope/permissions of the github token in use when encountering errors

### error message
<img width="911" alt="Screen Shot 2021-03-25 at 3 00 08 PM" src="https://user-images.githubusercontent.com/39655074/112549386-f3c17300-8d7a-11eb-8095-981324f1c144.png">

### initial token input
<img width="614" alt="Screen Shot 2021-03-25 at 3 00 21 PM" src="https://user-images.githubusercontent.com/39655074/112549387-f58b3680-8d7a-11eb-9b02-80836b8dee3f.png">
